### PR TITLE
Fixes deprecation warning in iOS 7: UITextAlignmentLeft -> NSTextAlignmentLeft

### DIFF
--- a/ECListView/ECListView.m
+++ b/ECListView/ECListView.m
@@ -92,7 +92,7 @@
                 } else {
                     UILabel *itemLabel = [[UILabel alloc] initWithFrame:CGRectMake(0.0, height, 0.0, 0.0)];
                     itemLabel.backgroundColor = [UIColor clearColor];
-                    itemLabel.textAlignment = UITextAlignmentLeft;
+                    itemLabel.textAlignment = NSTextAlignmentLeft;
                     itemLabel.font = self.font;
                     itemLabel.textColor = self.textColor;
                     


### PR DESCRIPTION
Hi, this minor change fixes a deprecation warning in iOS 7 by changing UITextAlignmentLeft -> NSTextAlignmentLeft.
